### PR TITLE
Revert namespace changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@andreicek/react-flickity-component",
-  "version": "0.0.1",
+  "name": "@realestate/react-flickity-component",
+  "version": "0.0.4",
   "description": "react flickity component",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Hi, I just realized that we have changed the package namespace in our fork.
This will revert it back.